### PR TITLE
Update to latest SDK 3.5.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,15 +41,14 @@ android {
 }
 
 dependencies {
-    def phraseVersion = "3.4.0"
-    def phraseComposeVersion = "3.2.5"
+    def phraseVersion = "3.5.0"
     def composeBom = platform('androidx.compose:compose-bom:2023.06.01')
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation "com.phrase.android:ota-sdk:$phraseVersion"
-    implementation "com.phrase.android:ota-sdk-compose:$phraseComposeVersion"
+    implementation "com.phrase.android:ota-sdk-compose:$phraseVersion"
     implementation composeBom
     implementation 'androidx.compose.material:material'
 


### PR DESCRIPTION
Use latest release 3.5.0. The core SDK and compose version and now released simultaneously  